### PR TITLE
fix(deploy): install devDependencies in Docker builder stage

### DIFF
--- a/DockerFile
+++ b/DockerFile
@@ -1,5 +1,7 @@
 FROM oven/bun:1.1.13 AS builder
 
+ENV NODE_ENV=development
+
 WORKDIR /app
 
 COPY package.json bun.lock ./
@@ -7,8 +9,7 @@ RUN bun install --frozen-lockfile
 
 COPY . .
 
-RUN rsbuild build && \
-    bun build --target=node --outfile=./dist/typesurvey.mjs ./server/app
+RUN bun run build
 
 FROM oven/bun:1.1.13-slim AS runner
 


### PR DESCRIPTION
## Problem

Docker build failed at the build step with `rsbuild: not found` (exit code 127).

## Root Cause

The `oven/bun` base image sets `NODE_ENV=production` by default, so `bun install` skipped devDependencies and `rsbuild` (`@rsbuild/core`) was never installed. Calling `rsbuild` directly in `RUN` is also fragile since `node_modules/.bin` is not on the shell PATH.

## Fix

- Set `ENV NODE_ENV=development` in the builder stage so devDependencies are installed
- Switch to `bun run build` to reuse the package.json script and resolve binaries from `node_modules/.bin`

The runner stage is unaffected — it only runs the self-contained `dist/typesurvey.mjs` bundle.
